### PR TITLE
Habilitar autenticación JWT y configuración asociada

### DIFF
--- a/MechanicalWorkShopWebApi.Api/MechanicalWorkShopWebApi.Api.csproj
+++ b/MechanicalWorkShopWebApi.Api/MechanicalWorkShopWebApi.Api.csproj
@@ -11,6 +11,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>

--- a/MechanicalWorkShopWebApi.Api/appsettings.json
+++ b/MechanicalWorkShopWebApi.Api/appsettings.json
@@ -8,5 +8,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "JwtSettings": {
+    "Secret": "5f80cccc80f3789a8eac811f0fa573ccad0d9a33930829fef5ef6dba72b6071e4c220a0adb968fe0105a72aff277b40806b1efdca9c5c3b9a2b9670db6d73655",
+    "Issuer": "MechanicalWorkShopApi",
+    "Audience": "MechanicalWorkShopClient",
+    "ExpiryMinutes": 1500,
+    "RefreshTokenExpiryMinutes": 10080
+  }
 }

--- a/MechanicalWorkShopWebApi.Domain/Settings/JwtSettings.cs
+++ b/MechanicalWorkShopWebApi.Domain/Settings/JwtSettings.cs
@@ -1,0 +1,10 @@
+﻿namespace MechanicalWorkShopWebApi.Domain.Settings
+{
+    public class JwtSettings
+    {
+        public string SecretKey { get; set; } = string.Empty;
+        public string Issuer { get; set; } = string.Empty;
+        public string Audience { get; set; } = string.Empty;
+        public int ExpirationInMinutes { get; set; }
+    }
+}


### PR DESCRIPTION
Habilitar autenticación JWT y configuración asociada

Se agregan paquetes NuGet para JWT y EF Core en el proyecto.
Se añade la sección JwtSettings en appsettings.json con los parámetros necesarios.
Se crea la clase JwtSettings para gestionar la configuración de tokens.
Preparación para implementar autenticación segura basada en JWT.

#### PR Classification
Implementación de autenticación JWT y configuración de Entity Framework Core en la API.

#### PR Summary
Se añaden dependencias y configuración necesarias para soportar autenticación basada en JWT y persistencia con Entity Framework Core.
- MechanicalWorkShopWebApi.Api.csproj: se agregan referencias a los paquetes de JWT y Entity Framework Core.
- appsettings.json: se añade la sección JwtSettings con parámetros de autenticación.
- JwtSettings.cs: se crea la clase JwtSettings para mapear la configuración de JWT.
